### PR TITLE
Prevent the loss of LS-FT during B4B

### DIFF
--- a/rotations/dragoon-bis.sl
+++ b/rotations/dragoon-bis.sl
@@ -1,16 +1,16 @@
 if (GlobalCooldownRemaining(self) > 0.5) {
 
-	if (TP(self) < 500 and IsReady(self, "invigorate"))
+	if (TP(self) < 460 and IsReady(self, "invigorate"))
 		use "invigorate";
 	
 	if (IsReady(self, "internal-release"))
 		use "internal-release";
 		
-	if (IsReady(self, "blood-for-blood"))
+	if (IsReady(self, "blood-for-blood") and !(IsReady(self, "full-thrust-combo") and AuraTimeRemaining(target, "chaos-thrust-dot", self) < 15.0))
 		use "blood-for-blood";
 	
-	if (IsReady(self, "power-surge") and AuraTimeRemaining(self, "blood-for-blood", self) > 3.0 and IsReady(self, "jump"))
-		use "power-surge";
+	if (IsReady(self, "power-surge") and AuraTimeRemaining(self, "blood-for-blood", self) > 3.0)
+                use "power-surge";
 		
 	if (IsReady(self, "life-surge") and IsReady(self, "full-thrust-combo") and AuraTimeRemaining(self, "blood-for-blood", self) > 1.0)
 		use "life-surge";


### PR DESCRIPTION
Delay B4B by one GCD if it comes up before Full Thrust to prevent the loss of a Life Surge Full Thrust during its duration. I'm seeing a DPS increase of about 5 on same seed for a 4 minute run.
