### PR TITLE
Give monks access to impulse drive, linker issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ On a fresh Ubuntu machine, the steps should go about like this:
 How to Use
 ==========
 
-`time ./simulator single-json subjects/monk-bis.conf rotations/monk.sl 660`
+`time ./simulator single-json --length 660 subjects/monk-bis.conf rotations/monk.sl`
 
 Runs a single 660 second simulation and spits out the detailed results formatted via JSON.
 
-`time ./simulator thorough-json subjects/monk-bis.conf rotations/monk.sl`
+`time ./simulator thorough-json subjects/monk-bis.conf rotations/monk.sl 660 661`
 
 Runs several hundred thousand simulations and spits out the results formatted via JSON.

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ OBJDIR = obj
 LLVM_CONFIG ?= llvm-config
 
 override CXXFLAGS += -g -Wall -O3 -std=c++1y `$(LLVM_CONFIG) --cppflags`
-override LDFLAGS += `$(LLVM_CONFIG) --ldflags --libs core support target executionengine jit native`
+override LDFLAGS += `$(LLVM_CONFIG) --ldflags --libs core support target executionengine jit native` -ltinfo -ldl
 
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(OBJDIR)/%.o,$(SRCS))

--- a/src/models/Monk.cpp
+++ b/src/models/Monk.cpp
@@ -322,6 +322,16 @@ Monk::Monk() : Base("monk") {
 		
 		_registerAction<Skill>();
 	}
+
+	{
+		struct Skill : Action {
+			Skill() : Action("impulse-drive-rear") {}
+			virtual int damage() const override { return 180; }
+			virtual int tpCost() const override { return 70; }
+		};
+
+		_registerAction<Skill>();
+	}
 }
 
 void Monk::prepareForBattle(Actor* actor) const {


### PR DESCRIPTION
Gives monks access to impulse drive, which is likely not part of
any good rotation but should be included for completeness.

Adds in a few libraries that are required to link on Ubuntu
with a fresh install of llvm.

Updates README.md to reflect new CLI interface.
