### PR TITLE
Rotation resilience to skill speed.

### DIFF
--- a/rotations/dragoon-bis.sl
+++ b/rotations/dragoon-bis.sl
@@ -1,21 +1,28 @@
 if (GlobalCooldownRemaining(self) > 0.5) {
 
-	if (TP(self) < 460 and IsReady(self, "invigorate"))
+	if (TP(self) < 450 and IsReady(self, "invigorate"))
 		use "invigorate";
 	
 	if (IsReady(self, "internal-release"))
 		use "internal-release";
 		
-	if (IsReady(self, "blood-for-blood") and !(IsReady(self, "full-thrust-combo") and AuraTimeRemaining(target, "chaos-thrust-dot", self) < 15.0))
-		use "blood-for-blood";
-	
-	if (IsReady(self, "power-surge") and AuraTimeRemaining(self, "blood-for-blood", self) > 3.0)
-                use "power-surge";
+    if (GlobalCooldown(self) < 2.4) {
+        if (IsReady(self, "blood-for-blood") and (IsReady(self, "chaos-thrust-combo") or IsReady(self, "full-thrust-combo")))
+            use "blood-for-blood";
+    } else {
+	    if (IsReady(self, "blood-for-blood") and !(IsReady(self, "full-thrust-combo") and AuraTimeRemaining(target, "chaos-thrust-dot", self) < 15.0))
+		    use "blood-for-blood";
+    }
 		
-	if (IsReady(self, "life-surge") and IsReady(self, "full-thrust-combo") and AuraTimeRemaining(self, "blood-for-blood", self) > 1.0)
+	if (IsReady(self, "life-surge") and IsReady(self, "full-thrust-combo") and AuraTimeRemaining(self, "blood-for-blood", self) > 0.5)
 		use "life-surge";
+	
+	if (IsReady(self, "power-surge") and AuraTimeRemaining(self, "blood-for-blood", self) > GlobalCooldown(self)) {
+	    if (CooldownRemaining(self, "jump") < AuraTimeRemaining(self, "blood-for-blood", self) - 2.0)
+                use "power-surge";
+	}
 		
-	if (IsReady(self, "jump"))
+	if (IsReady(self, "jump") and !(IsReady(self, "power-surge") and IsReady(self, "blood-for-blood")))
 		use "jump";
 	
 	if (IsReady(self, "leg-sweep"))
@@ -41,10 +48,10 @@ if (IsReady(self, "full-thrust-combo"))
 if (IsReady(self, "vorpal-thrust-combo"))
 	use "vorpal-thrust-combo";
 
-if (AuraTimeRemaining(self, "heavy-thrust", self) < 7.0)
+if (AuraTimeRemaining(self, "heavy-thrust", self) < 3.0 * GlobalCooldown(self))
 	use "heavy-thrust-flank";
 
-if (AuraTimeRemaining(target, "chaos-thrust-dot", self) < 6.0)
+if (AuraTimeRemaining(target, "chaos-thrust-dot", self) < 3.0*GlobalCooldown(self))
 	use "impulse-drive-rear";
 
 if (AuraTimeRemaining(target, "phlebotomize-dot", self) < 5.0)


### PR DESCRIPTION
Improvements to rotation scripting to account for varying skill speeds, should be about 2% improvement in performance for gear sets with high skill speed (ie. 470+).

Still not reaching the damage I parse myself at on dummies with same attributes, so there are clearly optimizations remaining to do. =\
