### PR TITLE
Various fixes and enhancements to Summoner model

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -55,11 +55,15 @@ void Actor::act(Actor* target) {
 	if (!action->isUsable(this)) { return; }
 
 	// TODO: get this out of here
-	bool swift = dispelAura("swiftcast", this);
+	bool swift = auraCount("swiftcast", this);
 
 	if (!swift && action->castTime(this).count()) {
 		_beginCast(action, target);
 	} else {
+		if (swift && action->castTime(this).count()) {
+			// Only actions with a cast time dispel Swiftcast
+			dispelAura("swiftcast", this);
+		}
 		_executeAction(action, target);
 	}
 }

--- a/src/models/Ifrit.cpp
+++ b/src/models/Ifrit.cpp
@@ -33,7 +33,15 @@ Ifrit::Ifrit() : Base("ifrit") {
 
 	{
 		struct Spell : Action {
-			Spell() : Action("inferno") {}
+			struct DoT : Aura {
+				DoT() : Aura("inferno-dot") {}
+				virtual std::chrono::microseconds duration() const override { return 15_s; }
+				virtual int tickDamage() const override { return 20; }
+			};
+
+			Spell() : Action("inferno") {
+				_targetAuras.push_back(new DoT());
+			}
 			virtual int damage() const override { return 200; }
 			virtual std::chrono::microseconds cooldown() const override { return 300_s; }
 			virtual void resolution(Actor* source, Actor* target, bool isCritical) const override {

--- a/src/models/Ifrit.cpp
+++ b/src/models/Ifrit.cpp
@@ -70,15 +70,15 @@ std::chrono::microseconds Ifrit::_baseGlobalCooldown(const Actor* actor) const {
 	return 3300_ms;
 }
 
-// TODO: this number may be wrong (was copied / pasted from monk)
-
 double Ifrit::_basePotencyMultiplier(const Actor* actor) const {
 	auto& stats = actor->stats();
-	return 0.01 * (stats.weaponPhysicalDamage * (stats.strength * 0.00389 + stats.determination * 0.0008 + 0.01035) + (stats.strength * 0.08034) + (stats.determination * 0.02622));
+	// TODO: unverified, but seems to work
+	return 0.01 * (stats.weaponPhysicalDamage * stats.intelligence * 0.00587517 + stats.determination * 0.074377 + stats.intelligence * 0.077076);
 }
 
 double Ifrit::_baseAutoAttackDamage(const Actor* actor) const {
 	auto& stats = actor->stats();
+	// TODO: this number may be wrong (was copied / pasted from monk)
 	return stats.weaponDelay / 3.0 * (stats.weaponPhysicalDamage * (stats.strength * 0.00408 + stats.determination * 0.00208 - 0.30991) + (stats.strength * 0.07149) + (stats.determination * 0.03443));
 }
 

--- a/src/models/Summoner.cpp
+++ b/src/models/Summoner.cpp
@@ -170,6 +170,25 @@ Summoner::Summoner() : Base("summoner") {
 		_registerAction<Spell>();
 	}
 
+	{
+		struct Spell : Action {
+			Spell() : Action("energy-drain") {}
+			virtual int damage() const override { return 150; }
+			virtual bool isOffGlobalCooldown() const override { return true; }
+			virtual std::chrono::microseconds cooldown() const override { return 3_s; }
+			// 266 at level 50
+			virtual int mpRestoration(const Actor* subject) const override { return 266; }
+			virtual void resolution(Actor* source, Actor* target, bool isCritical) const override {
+				source->dispelAura("aetherflow", source);
+			}
+			virtual bool requirements(const Actor* source) const override {
+				return source->auraCount("aetherflow", source);
+			}
+		};
+
+		_registerAction<Spell>();
+	}
+
 	{		
 		struct Spell : Action {
 			Spell() : Action("fester") {}

--- a/src/models/Summoner.cpp
+++ b/src/models/Summoner.cpp
@@ -30,12 +30,13 @@ Summoner::Summoner() : Base("summoner") {
 			struct DoT : Aura {
 				DoT() : Aura("bio-ii-dot") {}
 				virtual std::chrono::microseconds duration() const override { return 30_s; }
-				virtual int tickDamage() const override { return 30; }
+				virtual int tickDamage() const override { return 35; }
 			};
 			
 			Spell() : Action("bio-ii") {
 				_targetAuras.push_back(new DoT());
 			}
+			virtual std::chrono::microseconds castTime() const override { return 2500_ms; }
 			virtual int mpCost() const override { return 159; }
 		};
 	
@@ -54,6 +55,7 @@ Summoner::Summoner() : Base("summoner") {
 				_targetAuras.push_back(new DoT());
 			}
 			virtual int damage() const override { return 20; }
+			virtual std::chrono::microseconds castTime() const override { return 2500_ms; }
 			virtual int mpCost() const override { return 133; }
 		};
 	
@@ -197,7 +199,7 @@ Summoner::Summoner() : Base("summoner") {
 
 			Spell() : Action("rouse") {}
 			virtual bool isOffGlobalCooldown() const override { return true; }
-			virtual std::chrono::microseconds cooldown() const override { return 60_s; }
+			virtual std::chrono::microseconds cooldown() const override { return 90_s; }
 			virtual void resolution(Actor* source, Actor* target, bool isCritical) const override {
 				source->pet()->applyAura(&buff, source);
 			}

--- a/src/models/Summoner.cpp
+++ b/src/models/Summoner.cpp
@@ -85,7 +85,7 @@ Summoner::Summoner() : Base("summoner") {
 			Spell() : Action("ruin") {}
 			virtual int damage() const override { return 80; }
 			virtual std::chrono::microseconds castTime() const override { return 2500_ms; }
-			virtual int mpCost() const override { return 79; }
+			virtual int mpCost() const override { return 53; }
 		};
 	
 		_registerAction<Spell>();
@@ -95,7 +95,7 @@ Summoner::Summoner() : Base("summoner") {
 		struct Spell : Action {
 			Spell() : Action("ruin-ii") {}
 			virtual int damage() const override { return 80; }
-			virtual int mpCost() const override { return 133; }
+			virtual int mpCost() const override { return 106; }
 		};
 	
 		_registerAction<Spell>();


### PR DESCRIPTION
Fixes some action costs, cooldowns, and cast times to match the game.

Adjusts Swiftcast to only dispel after using an action with a cast time, as it is in the game.

Adds Energy Drain, with the intention of testing a rotation that includes the utilization of Ruin II to weave in off-GCD abilities (to address Issue #27).  Something like:

```
if (AuraCount(self, "swiftcast", self))
	use "shadow-flare";

if (IsReady(self, "raging-strikes")) {
	use "raging-strikes";
}

var garuda = Pet(self);
var needsWeave = false;
var globalCooldownActive = GlobalCooldownRemaining(self) > 0.8;

if (IsReady(garuda, "aerial-blast") and AuraTimeRemaining(garuda, "rouse", self) > 3.0 and AuraTimeRemaining(garuda, "spur", self) > 3.0)
	Command(garuda, "aerial-blast");
else if (!CooldownRemaining(garuda, "contagion") and AuraTimeRemaining(target, "bio-dot", self) > 10.0 and AuraTimeRemaining(target, "bio-ii-dot", self) > 10.0 and AuraTimeRemaining(target, "miasma-dot", self) > 10.0)
	Command(garuda, "contagion");

if (!CooldownRemaining(self, "aetherflow") and !AuraCount(self, "aetherflow", self)) {
	if (globalCooldownActive) {
		use "aetherflow";
	}
	needsWeave = true;
}

if (IsReady(self, "energy-drain") and MP(self) < 1900) {
	if (globalCooldownActive) {
		use "energy-drain";
	}
	needsWeave = true;
}

if (IsReady(self, "rouse")) {
	if (globalCooldownActive) {
		use "rouse";
	}
	needsWeave = true;
}

if (IsReady(self, "spur") and AuraCount(Pet(self), "rouse", self)) {
	if (globalCooldownActive) {
		use "spur";
	}
	needsWeave = true;
}

if (!AuraCount(target, "bio-dot", self))
	needsWeave = false;

if (!needsWeave) {
	if (!AuraCount(target, "bio-dot", self))
		use "bio";

	if (AuraTimeRemaining(target, "miasma-dot", self) < 2.0)
		use "miasma";

	if (AuraTimeRemaining(target, "bio-ii-dot", self) < 2.0)
		use "bio-ii";

	if (AuraTimeRemaining(target, "shadow-flare-dot", self) < 2.0) {
		if (CooldownRemaining(self, "swiftcast") > 10.0) {
			use "shadow-flare";
		} else if (!CooldownRemaining(self, "swiftcast")) {
			if (globalCooldownActive) {
				use "swiftcast";
			}
			needsWeave = true;
		}
	}
}

if (IsReady(self, "fester")) {
	if (globalCooldownActive) {
		use "fester";
	}
	needsWeave = true;
}

if (needsWeave)
	use "ruin-ii";

use "ruin";
```

According to the sim, however, that rotation doesn't increase DPS -- it translates to roughly the same as the current BiS rotation.