### PR TITLE
Use optimal races for BiS configs.

### DIFF
--- a/subjects/bard-bis.conf
+++ b/subjects/bard-bis.conf
@@ -1,10 +1,10 @@
-# http://ffxiv.ariyala.com/POPT
+# http://ffxiv.ariyala.com/PUCC
 
 model = bard
 
 weapon physical damage = 52
-weapon delay = 3.20
+weapon delay = 3.04
 dexterity = 658
 critical hit rate = 614
-determination = 322
+determination = 334
 skill speed = 356

--- a/subjects/bard-bis.conf
+++ b/subjects/bard-bis.conf
@@ -1,10 +1,10 @@
-# http://ffxiv.ariyala.com/P9WA
+# http://ffxiv.ariyala.com/POPT
 
 model = bard
 
 weapon physical damage = 52
 weapon delay = 3.20
-dexterity = 657
+dexterity = 658
 critical hit rate = 614
 determination = 322
 skill speed = 356

--- a/subjects/black-mage-bis.conf
+++ b/subjects/black-mage-bis.conf
@@ -1,4 +1,4 @@
-# http://ffxiv.ariyala.com/PE7Z
+# http://ffxiv.ariyala.com/PSU1
 
 model = black-mage
 
@@ -6,7 +6,7 @@ weapon physical damage = 58
 weapon magic damage = 82
 weapon delay = 3.28
 strength = 90
-intelligence = 660
+intelligence = 665
 piety = 242
 critical hit rate = 594
 determination = 227

--- a/subjects/black-mage-bis.conf
+++ b/subjects/black-mage-bis.conf
@@ -1,4 +1,4 @@
-# http://ffxiv.ariyala.com/PSU1
+# http://ffxiv.ariyala.com/PUCR
 
 model = black-mage
 
@@ -7,7 +7,7 @@ weapon magic damage = 82
 weapon delay = 3.28
 strength = 90
 intelligence = 665
-piety = 242
-critical hit rate = 594
-determination = 227
+piety = 240
+critical hit rate = 555
+determination = 213
 spell speed = 584

--- a/subjects/dragoon-bis.conf
+++ b/subjects/dragoon-bis.conf
@@ -1,10 +1,10 @@
-# http://ffxiv.ariyala.com/PSU3
+# http://ffxiv.ariyala.com/PUCW
 
 model = dragoon
 
 weapon physical damage = 58
-weapon delay = 2.88
+weapon delay = 2.96
 strength = 665
-critical hit rate = 558
+critical hit rate = 575
 determination = 359
 skill speed = 370

--- a/subjects/dragoon-bis.conf
+++ b/subjects/dragoon-bis.conf
@@ -1,10 +1,10 @@
-# http://ffxiv.ariyala.com/PE84
+# http://ffxiv.ariyala.com/PSU3
 
 model = dragoon
 
 weapon physical damage = 58
 weapon delay = 2.88
-strength = 663
+strength = 665
 critical hit rate = 558
 determination = 359
 skill speed = 370

--- a/subjects/monk-bis.conf
+++ b/subjects/monk-bis.conf
@@ -1,10 +1,10 @@
-# http://ffxiv.ariyala.com/PE5K
+# http://ffxiv.ariyala.com/PSU0
 
 model = monk
 
-weapon physical damage = 57
+weapon physical damage = 58
 weapon delay = 2.56
-strength = 653
+strength = 655
 critical hit rate = 456
 determination = 412
 skill speed = 385

--- a/subjects/ninja-bis.conf
+++ b/subjects/ninja-bis.conf
@@ -1,10 +1,10 @@
-# http://ffxiv.ariyala.com/PE83
+# http://ffxiv.ariyala.com/PSU7
 
 model = ninja
 
 weapon physical damage = 58
 weapon delay = 2.4
-dexterity = 654
+dexterity = 655
 critical hit rate = 529
 determination = 334
 skill speed = 433

--- a/subjects/ninja-bis.conf
+++ b/subjects/ninja-bis.conf
@@ -1,4 +1,4 @@
-# http://ffxiv.ariyala.com/PSU7
+# http://ffxiv.ariyala.com/PUD3
 
 model = ninja
 

--- a/subjects/summoner-bis.conf
+++ b/subjects/summoner-bis.conf
@@ -1,4 +1,4 @@
-# http://ffxiv.ariyala.com/PE85
+# http://ffxiv.ariyala.com/PSU8
 
 model = summoner
 pet = garuda
@@ -7,7 +7,7 @@ weapon physical damage = 58
 weapon magic damage = 82
 weapon delay = 3.12
 strength = 181
-intelligence = 660
+intelligence = 665
 piety = 212
 critical hit rate = 655
 determination = 242

--- a/subjects/summoner-bis.conf
+++ b/subjects/summoner-bis.conf
@@ -1,4 +1,4 @@
-# http://ffxiv.ariyala.com/PSU8
+# http://ffxiv.ariyala.com/PUD5
 
 model = summoner
 pet = garuda
@@ -8,7 +8,7 @@ weapon magic damage = 82
 weapon delay = 3.12
 strength = 181
 intelligence = 665
-piety = 212
-critical hit rate = 655
-determination = 242
-spell speed = 503
+piety = 210
+critical hit rate = 626
+determination = 256
+spell speed = 459


### PR DESCRIPTION
Warrior was already using the optimal race (most STR).  Modified the rest to use whichever race provided the most of their primary stat.