### PR TITLE
Ruin II-weaving rotation for SMN.

### DIFF
--- a/rotations/summoner-bis.sl
+++ b/rotations/summoner-bis.sl
@@ -1,41 +1,80 @@
 if (AuraCount(self, "swiftcast", self))
 	use "shadow-flare";
 
+if (IsReady(self, "raging-strikes")) {
+	use "raging-strikes";
+}
+
 var garuda = Pet(self);
+var needsWeave = false;
+var globalCooldownActive = GlobalCooldownRemaining(self) > 0.8;
 
 if (IsReady(garuda, "aerial-blast") and AuraTimeRemaining(garuda, "rouse", self) > 3.0 and AuraTimeRemaining(garuda, "spur", self) > 3.0)
 	Command(garuda, "aerial-blast");
 else if (!CooldownRemaining(garuda, "contagion") and AuraTimeRemaining(target, "bio-dot", self) > 10.0 and AuraTimeRemaining(target, "bio-ii-dot", self) > 10.0 and AuraTimeRemaining(target, "miasma-dot", self) > 10.0)
 	Command(garuda, "contagion");
 
-if (!CooldownRemaining(self, "raging-strikes"))
-	use "raging-strikes";
+if (!CooldownRemaining(self, "aetherflow") and !AuraCount(self, "aetherflow", self)) {
+	if (globalCooldownActive) {
+		use "aetherflow";
+	}
+	needsWeave = true;
+}
 
-if (!CooldownRemaining(self, "aetherflow") and !AuraCount(self, "aetherflow", self))
-	use "aetherflow";
+if (IsReady(self, "energy-drain") and MP(self) < 1500) {
+	if (globalCooldownActive) {
+		use "energy-drain";
+	}
+	needsWeave = true;
+}
 
-if (!CooldownRemaining(self, "rouse"))
-	use "rouse";
+if (IsReady(self, "rouse")) {
+	if (globalCooldownActive) {
+		use "rouse";
+	}
+	needsWeave = true;
+}
 
-if (!CooldownRemaining(self, "spur") and AuraCount(Pet(self), "rouse", self))
-	use "spur";
+if (IsReady(self, "spur") and AuraCount(Pet(self), "rouse", self)) {
+	if (globalCooldownActive) {
+		use "spur";
+	}
+	needsWeave = true;
+}
 
 if (!AuraCount(target, "bio-dot", self))
-	use "bio";
+	needsWeave = false;
 
-if (AuraTimeRemaining(target, "miasma-dot", self) < 2.0)
-	use "miasma";
+if (!needsWeave) {
+	if (!AuraCount(target, "bio-dot", self))
+		use "bio";
 
-if (AuraTimeRemaining(target, "bio-ii-dot", self) < 2.0)
-	use "bio-ii";
+	if (AuraTimeRemaining(target, "miasma-dot", self) < 2.0)
+		use "miasma";
 
-if (AuraTimeRemaining(target, "shadow-flare-dot", self) < 2.0)
-	if (CooldownRemaining(self, "swiftcast") > 10.0)
-		use "shadow-flare";
-	else if (!CooldownRemaining(self, "swiftcast"))
-		use "swiftcast";
+	if (AuraTimeRemaining(target, "bio-ii-dot", self) < 2.0)
+		use "bio-ii";
 
-if (AuraCount(self, "aetherflow", self) && !CooldownRemaining(self, "fester"))
-	use "fester";
+	if (AuraTimeRemaining(target, "shadow-flare-dot", self) < 2.0) {
+		if (CooldownRemaining(self, "swiftcast") > 10.0) {
+			use "shadow-flare";
+		} else if (!CooldownRemaining(self, "swiftcast")) {
+			if (globalCooldownActive) {
+				use "swiftcast";
+			}
+			needsWeave = true;
+		}
+	}
+}
+
+if (IsReady(self, "fester")) {
+	if (globalCooldownActive) {
+		use "fester";
+	}
+	needsWeave = true;
+}
+
+if (needsWeave or MP(self) > 1500)
+	use "ruin-ii";
 
 use "ruin";


### PR DESCRIPTION
Summoner rotation that includes the utilization of Ruin II to weave in off-GCD abilities, with Energy Drain to keep MP up.

If it's agreed that this is a better rotation (it looks better here, for certain), then this would also address Issue #27.